### PR TITLE
Backport "Verify stream size before allocating string / bytes."

### DIFF
--- a/pb_decode.c
+++ b/pb_decode.c
@@ -1431,6 +1431,9 @@ static bool checkreturn pb_dec_bytes(pb_istream_t *stream, const pb_field_t *fie
 #ifndef PB_ENABLE_MALLOC
         PB_RETURN_ERROR(stream, "no malloc support");
 #else
+        if (stream->bytes_left < size)
+            PB_RETURN_ERROR(stream, "end-of-stream");
+
 #ifdef PB_ENABLE_ADV_SIZE_CHECK
         /* field.max_size_limit == 0 disables pre-mem alloc check */
         if (field->max_size_limit > 0 && alloc_size > field->max_size_limit){
@@ -1473,6 +1476,9 @@ static bool checkreturn pb_dec_string(pb_istream_t *stream, const pb_field_t *fi
 #ifndef PB_ENABLE_MALLOC
         PB_RETURN_ERROR(stream, "no malloc support");
 #else
+        if (stream->bytes_left < size)
+            PB_RETURN_ERROR(stream, "end-of-stream");
+
 # ifdef PB_ENABLE_ADV_SIZE_CHECK
         /* field.max_size_limit == 0 disables pre- mem alloc check */
         if (field->max_size_limit > 0 && alloc_size > field->max_size_limit){


### PR DESCRIPTION
Upstream commit https://github.com/nanopb/nanopb/commit/2519119babea9e16ce5b14af50f87b4707865e8d:

    This stops ridicuously large mallocs from getting through
    on length-limited streams or buffers. Typically you should
    also override realloc() to limit allocation size yourself
    if dealing with untrusted data in pointer mode, but this
    at least limits the potential denial-of-service attacks.

Backport this patch in order to make fuzzing not crash as soon as the decoder tries to allocate a large buffer.